### PR TITLE
Add stats mode to makair-telemetry

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -8,12 +8,15 @@ extern crate clap;
 #[macro_use]
 extern crate log;
 
+mod statistics;
+
 use clap::Clap;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::BufWriter;
 use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 
+use statistics::*;
 use structures::*;
 use telemetry::*;
 
@@ -219,192 +222,5 @@ fn stats(cfg: Stats) {
                 std::process::exit(0);
             }
         }
-    }
-}
-
-fn compute_duration(messages: Vec<TelemetryMessage>) -> u32 {
-    let mut duration: u32 = 0;
-
-    for message in &messages {
-        match message {
-            TelemetryMessage::DataSnapshot(_) => {
-                duration += 10;
-            }
-
-            TelemetryMessage::StoppedMessage(_) => {
-                duration += 100;
-            }
-            _ => {}
-        }
-    }
-
-    duration
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_compute_duration_no_data() {
-        assert_eq!(compute_duration(vec![]), 0);
-    }
-
-    #[test]
-    fn test_compute_duration_one_boot_message() {
-        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::BootMessage(BootMessage {
-            version: String::from(""),
-            device_id: String::from(""),
-            systick: 0,
-            mode: Mode::Production,
-            value128: 0,
-        })];
-
-        assert_eq!(compute_duration(vect), 0);
-    }
-
-    #[test]
-    fn test_compute_duration_one_alarm_trap() {
-        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::AlarmTrap(AlarmTrap {
-            version: String::from(""),
-            device_id: String::from(""),
-            systick: 0,
-            centile: 0,
-            pressure: 0,
-            phase: Phase::Inhalation,
-            subphase: SubPhase::Inspiration,
-            cycle: 0,
-            alarm_code: 0,
-            alarm_priority: AlarmPriority::Low,
-            triggered: true,
-            expected: 0,
-            measured: 0,
-            cycles_since_trigger: 0,
-        })];
-
-        assert_eq!(compute_duration(vect), 0);
-    }
-
-    #[test]
-    fn test_compute_duration_one_data_snapshot() {
-        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::DataSnapshot(DataSnapshot {
-            version: String::from(""),
-            device_id: String::from(""),
-            systick: 0,
-            centile: 0,
-            pressure: 0,
-            phase: Phase::Inhalation,
-            subphase: SubPhase::Inspiration,
-            blower_valve_position: 0,
-            patient_valve_position: 0,
-            blower_rpm: 0,
-            battery_level: 0,
-        })];
-
-        assert_eq!(compute_duration(vect), 10);
-    }
-
-    #[test]
-    fn test_compute_duration_one_machine_state_snapshot() {
-        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::MachineStateSnapshot(
-            MachineStateSnapshot {
-                version: String::from(""),
-                device_id: String::from(""),
-                systick: 0,
-                cycle: 0,
-                peak_command: 0,
-                plateau_command: 0,
-                peep_command: 0,
-                cpm_command: 0,
-                previous_peak_pressure: 0,
-                previous_plateau_pressure: 0,
-                previous_peep_pressure: 0,
-                current_alarm_codes: vec![],
-            },
-        )];
-
-        assert_eq!(compute_duration(vect), 0);
-    }
-
-    #[test]
-    fn test_compute_duration_one_stopped_message() {
-        let mut vect: Vec<TelemetryMessage> = Vec::new();
-
-        vect.push(TelemetryMessage::StoppedMessage(StoppedMessage {
-            version: String::from(""),
-            device_id: String::from(""),
-            systick: 0,
-        }));
-
-        assert_eq!(compute_duration(vect), 100);
-    }
-
-    #[test]
-    fn test_compute_duration_one_of_each_message() {
-        let mut vect: Vec<TelemetryMessage> = Vec::new();
-
-        vect.push(TelemetryMessage::BootMessage(BootMessage {
-            version: String::from(""),
-            device_id: String::from(""),
-            systick: 0,
-            mode: Mode::Production,
-            value128: 0,
-        }));
-
-        vect.push(TelemetryMessage::AlarmTrap(AlarmTrap {
-            version: String::from(""),
-            device_id: String::from(""),
-            systick: 0,
-            centile: 0,
-            pressure: 0,
-            phase: Phase::Inhalation,
-            subphase: SubPhase::Inspiration,
-            cycle: 0,
-            alarm_code: 0,
-            alarm_priority: AlarmPriority::Low,
-            triggered: true,
-            expected: 0,
-            measured: 0,
-            cycles_since_trigger: 0,
-        }));
-
-        vect.push(TelemetryMessage::DataSnapshot(DataSnapshot {
-            version: String::from(""),
-            device_id: String::from(""),
-            systick: 0,
-            centile: 0,
-            pressure: 0,
-            phase: Phase::Inhalation,
-            subphase: SubPhase::Inspiration,
-            blower_valve_position: 0,
-            patient_valve_position: 0,
-            blower_rpm: 0,
-            battery_level: 0,
-        }));
-
-        vect.push(TelemetryMessage::MachineStateSnapshot(
-            MachineStateSnapshot {
-                version: String::from(""),
-                device_id: String::from(""),
-                systick: 0,
-                cycle: 0,
-                peak_command: 0,
-                plateau_command: 0,
-                peep_command: 0,
-                cpm_command: 0,
-                previous_peak_pressure: 0,
-                previous_plateau_pressure: 0,
-                previous_peep_pressure: 0,
-                current_alarm_codes: vec![],
-            },
-        ));
-
-        vect.push(TelemetryMessage::StoppedMessage(StoppedMessage {
-            version: String::from(""),
-            device_id: String::from(""),
-            systick: 0,
-        }));
-
-        assert_eq!(compute_duration(vect), 110);
     }
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -180,8 +180,8 @@ fn stats(cfg: Stats) {
 
     loop {
         match rx.try_recv() {
-            Ok(channel_message) => match channel_message {
-                Ok(message) => {
+            Ok(channel_message) => {
+                if let Ok(message) = channel_message {
                     match message {
                         TelemetryMessage::BootMessage(_) => {
                             nb_boot_messages += 1;
@@ -201,8 +201,7 @@ fn stats(cfg: Stats) {
                     }
                     telemetry_messages.push(message);
                 }
-                _ => {}
-            },
+            }
             Err(TryRecvError::Empty) => {
                 std::thread::sleep(std::time::Duration::from_millis(1));
             }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -263,22 +263,20 @@ mod tests {
 
     #[test]
     fn test_compute_duration_one_boot_message() {
-        let mut vect: Vec<TelemetryMessage> = Vec::new();
-        vect.push(TelemetryMessage::BootMessage(BootMessage {
+        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::BootMessage(BootMessage {
             version: String::from(""),
             device_id: String::from(""),
             systick: 0,
             mode: Mode::Production,
             value128: 0,
-        }));
+        })];
 
         assert_eq!(compute_duration(vect), 0);
     }
 
     #[test]
     fn test_compute_duration_one_alarm_trap() {
-        let mut vect: Vec<TelemetryMessage> = Vec::new();
-        vect.push(TelemetryMessage::AlarmTrap(AlarmTrap {
+        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::AlarmTrap(AlarmTrap {
             version: String::from(""),
             device_id: String::from(""),
             systick: 0,
@@ -293,15 +291,14 @@ mod tests {
             expected: 0,
             measured: 0,
             cycles_since_trigger: 0,
-        }));
+        })];
 
         assert_eq!(compute_duration(vect), 0);
     }
 
     #[test]
     fn test_compute_duration_one_data_snapshot() {
-        let mut vect: Vec<TelemetryMessage> = Vec::new();
-        vect.push(TelemetryMessage::DataSnapshot(DataSnapshot {
+        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::DataSnapshot(DataSnapshot {
             version: String::from(""),
             device_id: String::from(""),
             systick: 0,
@@ -313,15 +310,14 @@ mod tests {
             patient_valve_position: 0,
             blower_rpm: 0,
             battery_level: 0,
-        }));
+        })];
 
         assert_eq!(compute_duration(vect), 10);
     }
 
     #[test]
     fn test_compute_duration_one_machine_state_snapshot() {
-        let mut vect: Vec<TelemetryMessage> = Vec::new();
-        vect.push(TelemetryMessage::MachineStateSnapshot(
+        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::MachineStateSnapshot(
             MachineStateSnapshot {
                 version: String::from(""),
                 device_id: String::from(""),
@@ -336,7 +332,7 @@ mod tests {
                 previous_peep_pressure: 0,
                 current_alarm_codes: vec![],
             },
-        ));
+        )];
 
         assert_eq!(compute_duration(vect), 0);
     }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -8,8 +8,6 @@ extern crate clap;
 #[macro_use]
 extern crate log;
 
-extern crate base64;
-
 use clap::Clap;
 use std::fs::File;
 use std::fs::OpenOptions;
@@ -17,7 +15,6 @@ use std::io::BufWriter;
 use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 
 use structures::*;
-
 use telemetry::*;
 
 #[derive(Clap)]
@@ -177,7 +174,7 @@ fn play(cfg: Play) {
 }
 
 fn stats(cfg: Stats) {
-    let file = File::open(cfg.input).expect("failed to compute statistics for recorded file");
+    let file = File::open(cfg.input).expect("failed to open given recorded file");
 
     let (tx, rx): (Sender<TelemetryChannelType>, Receiver<TelemetryChannelType>) =
         std::sync::mpsc::channel();
@@ -257,7 +254,6 @@ fn compute_duration(messages: Vec<TelemetryMessage>) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;
 
     #[test]

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -142,24 +142,12 @@ fn play(cfg: Play) {
         std::sync::mpsc::channel();
     std::thread::spawn(move || {
         info!("start playing telemetry messages");
-        gather_telemetry_from_file(file, tx);
+        gather_telemetry_from_file(file, tx, true);
     });
-
-    let stopped_message_period = std::time::Duration::from_millis(100);
-    let data_message_period = std::time::Duration::from_millis(10);
 
     loop {
         match rx.try_recv() {
             Ok(msg) => {
-                match msg {
-                    Ok(TelemetryMessage::StoppedMessage { .. }) => {
-                        std::thread::sleep(stopped_message_period);
-                    }
-                    Ok(TelemetryMessage::DataSnapshot { .. }) => {
-                        std::thread::sleep(data_message_period);
-                    }
-                    _ => (),
-                }
                 display_message(msg);
             }
             Err(TryRecvError::Empty) => {
@@ -179,7 +167,7 @@ fn stats(cfg: Stats) {
     let (tx, rx): (Sender<TelemetryChannelType>, Receiver<TelemetryChannelType>) =
         std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        gather_telemetry_from_file(file, tx);
+        gather_telemetry_from_file(file, tx, false);
     });
 
     let mut telemetry_messages: Vec<TelemetryMessage> = Vec::new();

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -180,27 +180,29 @@ fn stats(cfg: Stats) {
 
     loop {
         match rx.try_recv() {
-            Ok(message) => {
-                match message {
-                    Ok(TelemetryMessage::BootMessage(_)) => {
-                        nb_boot_messages += 1;
+            Ok(channel_message) => match channel_message {
+                Ok(message) => {
+                    match message {
+                        TelemetryMessage::BootMessage(_) => {
+                            nb_boot_messages += 1;
+                        }
+                        TelemetryMessage::AlarmTrap(_) => {
+                            nb_alarm_traps += 1;
+                        }
+                        TelemetryMessage::DataSnapshot(_) => {
+                            nb_data_snapshots += 1;
+                        }
+                        TelemetryMessage::MachineStateSnapshot(_) => {
+                            nb_machine_state_snapshots += 1;
+                        }
+                        TelemetryMessage::StoppedMessage(_) => {
+                            nb_stopped_messages += 1;
+                        }
                     }
-                    Ok(TelemetryMessage::AlarmTrap(_)) => {
-                        nb_alarm_traps += 1;
-                    }
-                    Ok(TelemetryMessage::DataSnapshot(_)) => {
-                        nb_data_snapshots += 1;
-                    }
-                    Ok(TelemetryMessage::MachineStateSnapshot(_)) => {
-                        nb_machine_state_snapshots += 1;
-                    }
-                    Ok(TelemetryMessage::StoppedMessage(_)) => {
-                        nb_stopped_messages += 1;
-                    }
-                    _ => {}
+                    telemetry_messages.push(message);
                 }
-                telemetry_messages.push(message.unwrap());
-            }
+                _ => {}
+            },
             Err(TryRecvError::Empty) => {
                 std::thread::sleep(std::time::Duration::from_millis(1));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate log;
 extern crate nom;
 
 pub mod alarm;
-mod parsers;
+pub mod parsers;
 pub mod structures;
 
 pub use serial;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate log;
 extern crate nom;
 
 pub mod alarm;
-pub mod parsers;
+mod parsers;
 pub mod structures;
 
 pub use serial;
@@ -176,11 +176,6 @@ pub fn gather_telemetry_from_file(file: File, tx: Sender<TelemetryChannelType>) 
     let reader = BufReader::new(file);
     let mut buffer = Vec::new();
 
-    let stopped_message_period = std::time::Duration::from_millis(100);
-    let data_message_period = std::time::Duration::from_millis(10);
-
-    info!("start playing telemetry messages");
-
     for line in reader.lines() {
         if let Ok(line_str) = line {
             if let Ok(mut bytes) = base64::decode(line_str) {
@@ -191,15 +186,6 @@ pub fn gather_telemetry_from_file(file: File, tx: Sender<TelemetryChannelType>) 
                     match parse_telemetry_message(&buffer) {
                         // It worked! Let's extract the message and replace the buffer with the rest of the bytes
                         Ok((rest, message)) => {
-                            match message {
-                                TelemetryMessage::StoppedMessage { .. } => {
-                                    std::thread::sleep(stopped_message_period);
-                                }
-                                TelemetryMessage::DataSnapshot { .. } => {
-                                    std::thread::sleep(data_message_period);
-                                }
-                                _ => (),
-                            }
                             tx.send(Ok(message))
                                 .expect("failed sending message to tx channel");
                             buffer = Vec::from(rest);

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1,0 +1,193 @@
+// MakAir
+//
+// Copyright: 2020, Makers For Life
+// License: Public Domain License
+
+use crate::structures::*;
+
+pub fn compute_duration(messages: Vec<TelemetryMessage>) -> u32 {
+    let mut duration: u32 = 0;
+
+    for message in &messages {
+        match message {
+            TelemetryMessage::DataSnapshot(_) => {
+                duration += 10;
+            }
+
+            TelemetryMessage::StoppedMessage(_) => {
+                duration += 100;
+            }
+            _ => {}
+        }
+    }
+
+    duration
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_duration_no_data() {
+        assert_eq!(compute_duration(vec![]), 0);
+    }
+
+    #[test]
+    fn test_compute_duration_one_boot_message() {
+        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::BootMessage(BootMessage {
+            version: String::from(""),
+            device_id: String::from(""),
+            systick: 0,
+            mode: Mode::Production,
+            value128: 0,
+        })];
+
+        assert_eq!(compute_duration(vect), 0);
+    }
+
+    #[test]
+    fn test_compute_duration_one_alarm_trap() {
+        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::AlarmTrap(AlarmTrap {
+            version: String::from(""),
+            device_id: String::from(""),
+            systick: 0,
+            centile: 0,
+            pressure: 0,
+            phase: Phase::Inhalation,
+            subphase: SubPhase::Inspiration,
+            cycle: 0,
+            alarm_code: 0,
+            alarm_priority: AlarmPriority::Low,
+            triggered: true,
+            expected: 0,
+            measured: 0,
+            cycles_since_trigger: 0,
+        })];
+
+        assert_eq!(compute_duration(vect), 0);
+    }
+
+    #[test]
+    fn test_compute_duration_one_data_snapshot() {
+        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::DataSnapshot(DataSnapshot {
+            version: String::from(""),
+            device_id: String::from(""),
+            systick: 0,
+            centile: 0,
+            pressure: 0,
+            phase: Phase::Inhalation,
+            subphase: SubPhase::Inspiration,
+            blower_valve_position: 0,
+            patient_valve_position: 0,
+            blower_rpm: 0,
+            battery_level: 0,
+        })];
+
+        assert_eq!(compute_duration(vect), 10);
+    }
+
+    #[test]
+    fn test_compute_duration_one_machine_state_snapshot() {
+        let vect: Vec<TelemetryMessage> = vec![TelemetryMessage::MachineStateSnapshot(
+            MachineStateSnapshot {
+                version: String::from(""),
+                device_id: String::from(""),
+                systick: 0,
+                cycle: 0,
+                peak_command: 0,
+                plateau_command: 0,
+                peep_command: 0,
+                cpm_command: 0,
+                previous_peak_pressure: 0,
+                previous_plateau_pressure: 0,
+                previous_peep_pressure: 0,
+                current_alarm_codes: vec![],
+            },
+        )];
+
+        assert_eq!(compute_duration(vect), 0);
+    }
+
+    #[test]
+    fn test_compute_duration_one_stopped_message() {
+        let mut vect: Vec<TelemetryMessage> = Vec::new();
+
+        vect.push(TelemetryMessage::StoppedMessage(StoppedMessage {
+            version: String::from(""),
+            device_id: String::from(""),
+            systick: 0,
+        }));
+
+        assert_eq!(compute_duration(vect), 100);
+    }
+
+    #[test]
+    fn test_compute_duration_one_of_each_message() {
+        let mut vect: Vec<TelemetryMessage> = Vec::new();
+
+        vect.push(TelemetryMessage::BootMessage(BootMessage {
+            version: String::from(""),
+            device_id: String::from(""),
+            systick: 0,
+            mode: Mode::Production,
+            value128: 0,
+        }));
+
+        vect.push(TelemetryMessage::AlarmTrap(AlarmTrap {
+            version: String::from(""),
+            device_id: String::from(""),
+            systick: 0,
+            centile: 0,
+            pressure: 0,
+            phase: Phase::Inhalation,
+            subphase: SubPhase::Inspiration,
+            cycle: 0,
+            alarm_code: 0,
+            alarm_priority: AlarmPriority::Low,
+            triggered: true,
+            expected: 0,
+            measured: 0,
+            cycles_since_trigger: 0,
+        }));
+
+        vect.push(TelemetryMessage::DataSnapshot(DataSnapshot {
+            version: String::from(""),
+            device_id: String::from(""),
+            systick: 0,
+            centile: 0,
+            pressure: 0,
+            phase: Phase::Inhalation,
+            subphase: SubPhase::Inspiration,
+            blower_valve_position: 0,
+            patient_valve_position: 0,
+            blower_rpm: 0,
+            battery_level: 0,
+        }));
+
+        vect.push(TelemetryMessage::MachineStateSnapshot(
+            MachineStateSnapshot {
+                version: String::from(""),
+                device_id: String::from(""),
+                systick: 0,
+                cycle: 0,
+                peak_command: 0,
+                plateau_command: 0,
+                peep_command: 0,
+                cpm_command: 0,
+                previous_peak_pressure: 0,
+                previous_plateau_pressure: 0,
+                previous_peep_pressure: 0,
+                current_alarm_codes: vec![],
+            },
+        ));
+
+        vect.push(TelemetryMessage::StoppedMessage(StoppedMessage {
+            version: String::from(""),
+            device_id: String::from(""),
+            systick: 0,
+        }));
+
+        assert_eq!(compute_duration(vect), 110);
+    }
+}


### PR DESCRIPTION
This option will provide a useful mode which compute some statistics about a record file.
It will sum of each kind of TelemetryMessage and an estimated duration of the record.