### PR TITLE
Various additions

### DIFF
--- a/src/cli/bin.rs
+++ b/src/cli/bin.rs
@@ -320,6 +320,7 @@ fn stats(cfg: Stats) {
     let mut nb_stopped_messages: u32 = 0;
     let mut nb_control_ack: u32 = 0;
     let mut nb_fatal_error: u32 = 0;
+    let mut nb_eol_test_snapshots: u32 = 0;
 
     loop {
         match rx.try_recv() {
@@ -347,6 +348,9 @@ fn stats(cfg: Stats) {
                         TelemetryMessage::FatalError(_) => {
                             nb_fatal_error += 1;
                         }
+                        TelemetryMessage::EolTestSnapshot(_) => {
+                            nb_eol_test_snapshots += 1;
+                        }
                     }
                     telemetry_messages.push(message);
                 }
@@ -363,6 +367,7 @@ fn stats(cfg: Stats) {
                 println!("Nb StoppedMessage: {}", nb_stopped_messages);
                 println!("Nb ControlAck: {}", nb_control_ack);
                 println!("Nb FatalError: {}", nb_fatal_error);
+                println!("Nb EolTestSnapshot: {}", nb_eol_test_snapshots);
                 println!(
                     "Estimated duration: {:.3} seconds",
                     compute_duration(telemetry_messages) as f32 / 1000_f32

--- a/src/cli/bin.rs
+++ b/src/cli/bin.rs
@@ -319,6 +319,7 @@ fn stats(cfg: Stats) {
     let mut nb_machine_state_snapshots: u32 = 0;
     let mut nb_stopped_messages: u32 = 0;
     let mut nb_control_ack: u32 = 0;
+    let mut nb_fatal_error: u32 = 0;
 
     loop {
         match rx.try_recv() {
@@ -343,6 +344,9 @@ fn stats(cfg: Stats) {
                         TelemetryMessage::ControlAck(_) => {
                             nb_control_ack += 1;
                         }
+                        TelemetryMessage::FatalError(_) => {
+                            nb_fatal_error += 1;
+                        }
                     }
                     telemetry_messages.push(message);
                 }
@@ -358,6 +362,7 @@ fn stats(cfg: Stats) {
                 println!("Nb MachineStateSnapshot: {}", nb_machine_state_snapshots);
                 println!("Nb StoppedMessage: {}", nb_stopped_messages);
                 println!("Nb ControlAck: {}", nb_control_ack);
+                println!("Nb FatalError: {}", nb_fatal_error);
                 println!(
                     "Estimated duration: {:.3} seconds",
                     compute_duration(telemetry_messages) as f32 / 1000_f32

--- a/src/cli/convert.rs
+++ b/src/cli/convert.rs
@@ -162,6 +162,9 @@ pub fn telemetry_to_gts(message: &TelemetryMessage, source_label: &Option<String
         TelemetryMessage::ControlAck(_) => {
             // Do nothing: we don't want this kind of messages
         }
+        TelemetryMessage::FatalError(_) => {
+            // Do nothing: we don't want this kind of messages
+        }
     };
     output.iter().fold(String::new(), |mut acc, cur| {
         acc.push_str(cur);

--- a/src/cli/convert.rs
+++ b/src/cli/convert.rs
@@ -165,6 +165,9 @@ pub fn telemetry_to_gts(message: &TelemetryMessage, source_label: &Option<String
         TelemetryMessage::FatalError(_) => {
             // Do nothing: we don't want this kind of messages
         }
+        TelemetryMessage::EolTestSnapshot(_) => {
+            // Do nothing: we don't want this kind of messages
+        }
     };
     output.iter().fold(String::new(), |mut acc, cur| {
         acc.push_str(cur);

--- a/src/cli/statistics.rs
+++ b/src/cli/statistics.rs
@@ -137,6 +137,7 @@ mod tests {
                 previous_inspiratory_duration: None,
                 battery_level: None,
                 patient_height: None,
+                locale: None,
             },
         )];
 
@@ -182,6 +183,7 @@ mod tests {
             battery_level: None,
             current_alarm_codes: None,
             patient_height: None,
+            locale: None,
         }));
 
         assert_eq!(compute_duration(vect), 100);
@@ -278,6 +280,7 @@ mod tests {
                 previous_inspiratory_duration: None,
                 battery_level: None,
                 patient_height: None,
+                locale: None,
             },
         ));
 
@@ -316,6 +319,7 @@ mod tests {
             battery_level: None,
             current_alarm_codes: None,
             patient_height: None,
+            locale: None,
         }));
 
         assert_eq!(compute_duration(vect), 110);

--- a/src/cli/statistics.rs
+++ b/src/cli/statistics.rs
@@ -136,6 +136,7 @@ mod tests {
                 inspiratory_duration_command: None,
                 previous_inspiratory_duration: None,
                 battery_level: None,
+                patient_height: None,
             },
         )];
 
@@ -180,6 +181,7 @@ mod tests {
             inspiratory_duration_command: None,
             battery_level: None,
             current_alarm_codes: None,
+            patient_height: None,
         }));
 
         assert_eq!(compute_duration(vect), 100);
@@ -275,6 +277,7 @@ mod tests {
                 inspiratory_duration_command: None,
                 previous_inspiratory_duration: None,
                 battery_level: None,
+                patient_height: None,
             },
         ));
 
@@ -312,6 +315,7 @@ mod tests {
             inspiratory_duration_command: None,
             battery_level: None,
             current_alarm_codes: None,
+            patient_height: None,
         }));
 
         assert_eq!(compute_duration(vect), 110);

--- a/src/control.rs
+++ b/src/control.rs
@@ -75,6 +75,8 @@ pub enum ControlSetting {
     InspiratoryDuration = 26,
     /// Language of the UI; this should be two letters (see [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1)) in ASCII representation as two u8
     Locale = 27,
+    /// Patient's height in centimeters
+    PatientHeight = 28,
 }
 
 impl ControlSetting {
@@ -110,6 +112,7 @@ impl ControlSetting {
             Self::TargetInspiratoryFlow => 40,
             Self::InspiratoryDuration => 800,
             Self::Locale => Locale::default().as_usize(),
+            Self::PatientHeight => 160,
         }
     }
 
@@ -145,6 +148,7 @@ impl ControlSetting {
             Self::TargetInspiratoryFlow => RangeInclusive::new(5, 80),
             Self::InspiratoryDuration => RangeInclusive::new(200, 3_000),
             Self::Locale => Locale::bounds(),
+            Self::PatientHeight => RangeInclusive::new(100, 250),
         }
     }
 }
@@ -182,6 +186,7 @@ impl std::convert::TryFrom<u8> for ControlSetting {
             25 => Ok(ControlSetting::TargetInspiratoryFlow),
             26 => Ok(ControlSetting::InspiratoryDuration),
             27 => Ok(ControlSetting::Locale),
+            28 => Ok(ControlSetting::PatientHeight),
             _ => Err("Invalid setting number"),
         }
     }

--- a/src/control.rs
+++ b/src/control.rs
@@ -73,7 +73,7 @@ pub enum ControlSetting {
     TargetInspiratoryFlow = 25,
     /// Duration of inspiration in ms (value bounds must be between 200 and 3000)
     InspiratoryDuration = 26,
-    /// Language of the UI; this should be two letters (see [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1)) in ASCII representation as two u8
+    /// Language of the system; this should be two letters (see [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1)) in ASCII representation as two u8
     Locale = 27,
     /// Patient's height in centimeters
     PatientHeight = 28,

--- a/src/control.rs
+++ b/src/control.rs
@@ -5,6 +5,8 @@
 
 use std::ops::RangeInclusive;
 
+use crate::locale::UiLocale;
+
 /// Special value that can be used in a heartbeat control message to disable RPi watchdog
 pub const DISABLE_RPI_WATCHDOG: u16 = 43_690;
 
@@ -71,6 +73,8 @@ pub enum ControlSetting {
     TargetInspiratoryFlow = 25,
     /// Duration of inspiration in ms (value bounds must be between 200 and 3000)
     InspiratoryDuration = 26,
+    /// Language of the UI; this should be two letters (see [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1)) in ASCII representation as two u8
+    UiLocale = 27,
 }
 
 impl ControlSetting {
@@ -105,6 +109,7 @@ impl ControlSetting {
             Self::LeakAlarmThreshold => 200,
             Self::TargetInspiratoryFlow => 40,
             Self::InspiratoryDuration => 800,
+            Self::UiLocale => UiLocale::default().as_usize(),
         }
     }
 
@@ -139,6 +144,7 @@ impl ControlSetting {
             Self::LeakAlarmThreshold => RangeInclusive::new(0, 10_000),
             Self::TargetInspiratoryFlow => RangeInclusive::new(5, 80),
             Self::InspiratoryDuration => RangeInclusive::new(200, 3_000),
+            Self::UiLocale => UiLocale::bounds(),
         }
     }
 }
@@ -175,6 +181,7 @@ impl std::convert::TryFrom<u8> for ControlSetting {
             24 => Ok(ControlSetting::LeakAlarmThreshold),
             25 => Ok(ControlSetting::TargetInspiratoryFlow),
             26 => Ok(ControlSetting::InspiratoryDuration),
+            27 => Ok(ControlSetting::UiLocale),
             _ => Err("Invalid setting number"),
         }
     }

--- a/src/control.rs
+++ b/src/control.rs
@@ -5,7 +5,7 @@
 
 use std::ops::RangeInclusive;
 
-use crate::locale::UiLocale;
+use crate::locale::Locale;
 
 /// Special value that can be used in a heartbeat control message to disable RPi watchdog
 pub const DISABLE_RPI_WATCHDOG: u16 = 43_690;
@@ -74,7 +74,7 @@ pub enum ControlSetting {
     /// Duration of inspiration in ms (value bounds must be between 200 and 3000)
     InspiratoryDuration = 26,
     /// Language of the UI; this should be two letters (see [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1)) in ASCII representation as two u8
-    UiLocale = 27,
+    Locale = 27,
 }
 
 impl ControlSetting {
@@ -109,7 +109,7 @@ impl ControlSetting {
             Self::LeakAlarmThreshold => 200,
             Self::TargetInspiratoryFlow => 40,
             Self::InspiratoryDuration => 800,
-            Self::UiLocale => UiLocale::default().as_usize(),
+            Self::Locale => Locale::default().as_usize(),
         }
     }
 
@@ -144,7 +144,7 @@ impl ControlSetting {
             Self::LeakAlarmThreshold => RangeInclusive::new(0, 10_000),
             Self::TargetInspiratoryFlow => RangeInclusive::new(5, 80),
             Self::InspiratoryDuration => RangeInclusive::new(200, 3_000),
-            Self::UiLocale => UiLocale::bounds(),
+            Self::Locale => Locale::bounds(),
         }
     }
 }
@@ -181,7 +181,7 @@ impl std::convert::TryFrom<u8> for ControlSetting {
             24 => Ok(ControlSetting::LeakAlarmThreshold),
             25 => Ok(ControlSetting::TargetInspiratoryFlow),
             26 => Ok(ControlSetting::InspiratoryDuration),
-            27 => Ok(ControlSetting::UiLocale),
+            27 => Ok(ControlSetting::Locale),
             _ => Err("Invalid setting number"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,12 @@ pub fn display_message(message: TelemetryChannelType) {
         }))) => {
             info!("***** FATAL ERROR ***** {:?}", &error);
         }
+        Ok(TelemetryMessageOrError::Message(TelemetryMessage::EolTestSnapshot(_))) => {
+            info!(
+                "    {:?}",
+                &message.expect("failed unwrapping message for EOL test snapshot")
+            );
+        }
         Ok(TelemetryMessageOrError::Error(e)) => {
             warn!("a high-level error occurred: {:?}", e);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,12 @@ pub fn display_message(message: TelemetryChannelType) {
         }))) => {
             info!("← {:?} = {}", &setting, &value);
         }
+        Ok(TelemetryMessageOrError::Message(TelemetryMessage::FatalError(FatalError {
+            error,
+            ..
+        }))) => {
+            info!("***** FATAL ERROR ***** {:?}", &error);
+        }
         Ok(TelemetryMessageOrError::Error(e)) => {
             warn!("a high-level error occurred: {:?}", e);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 pub mod alarm;
 /// Structures to represent control messages
 pub mod control;
+/// Tools to manipulate ISO 639-1 language codes to be used in the control protocol
+pub mod locale;
 /// Underlying parsers for telemetry messages
 pub mod parsers;
 /// Structures to represent telemetry messages

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -1,0 +1,77 @@
+// MakAir Telemetry
+//
+// Copyright: 2020, Makers For Life
+// License: Public Domain License
+
+use std::convert::TryFrom;
+use std::ops::RangeInclusive;
+
+/// An ISO 639-1 language code to be used to choose language for the ControlUI
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UiLocale(u16);
+
+impl UiLocale {
+    /// Language code as a u16
+    pub fn as_u16(&self) -> u16 {
+        self.0
+    }
+
+    /// Language code as a usize
+    pub fn as_usize(&self) -> usize {
+        self.0.into()
+    }
+
+    /// Allowed value bounds
+    pub fn bounds() -> RangeInclusive<usize> {
+        RangeInclusive::new(
+            Self::try_from("aa").unwrap().as_usize(),
+            Self::try_from("zz").unwrap().as_usize(),
+        )
+    }
+}
+
+impl TryFrom<&str> for UiLocale {
+    type Error = &'static str;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        if value.len() == 2 {
+            let bytes = value.as_bytes();
+            let w = ((bytes[0] as u16) << 8) | bytes[1] as u16;
+            Ok(UiLocale(w))
+        } else {
+            Err("language code must be exactly 2 characters, according to ISO 639-1")
+        }
+    }
+}
+
+impl Default for UiLocale {
+    fn default() -> Self {
+        UiLocale::try_from("en").unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UiLocale;
+
+    use std::convert::TryFrom;
+
+    #[test]
+    fn fr() {
+        let expected: u16 = 0x6672;
+        assert_eq!(
+            UiLocale::try_from("fr").map(|code| code.as_u16()),
+            Ok(expected)
+        );
+    }
+
+    #[test]
+    fn empty() {
+        assert!(UiLocale::try_from("").is_err())
+    }
+
+    #[test]
+    fn too_long() {
+        assert!(UiLocale::try_from("fra").is_err())
+    }
+}

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -8,9 +8,18 @@ use std::ops::RangeInclusive;
 
 /// An ISO 639-1 language code to be used to choose language for the whole system
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize-messages", derive(serde::Serialize))]
 pub struct Locale(u16);
 
 impl Locale {
+    /// Create a locale from a u16
+    pub fn try_from_u16(num: u16) -> Option<Self> {
+        match Self::try_from(Self(num).to_string().as_str()) {
+            Ok(locale) => Some(locale),
+            Err(_) => None,
+        }
+    }
+
     /// Language code as a u16
     pub fn as_u16(&self) -> u16 {
         self.0

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -6,11 +6,11 @@
 use std::convert::TryFrom;
 use std::ops::RangeInclusive;
 
-/// An ISO 639-1 language code to be used to choose language for the ControlUI
+/// An ISO 639-1 language code to be used to choose language for the whole system
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct UiLocale(u16);
+pub struct Locale(u16);
 
-impl UiLocale {
+impl Locale {
     /// Language code as a u16
     pub fn as_u16(&self) -> u16 {
         self.0
@@ -30,27 +30,27 @@ impl UiLocale {
     }
 }
 
-impl TryFrom<&str> for UiLocale {
+impl TryFrom<&str> for Locale {
     type Error = &'static str;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         if value.len() == 2 {
             let bytes = value.as_bytes();
             let w = ((bytes[0] as u16) << 8) | bytes[1] as u16;
-            Ok(UiLocale(w))
+            Ok(Locale(w))
         } else {
             Err("language code must be exactly 2 characters, according to ISO 639-1")
         }
     }
 }
 
-impl Default for UiLocale {
+impl Default for Locale {
     fn default() -> Self {
-        UiLocale::try_from("en").unwrap()
+        Locale::try_from("en").unwrap()
     }
 }
 
-impl std::fmt::Display for UiLocale {
+impl std::fmt::Display for Locale {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let bytes = self.0.to_be_bytes();
         let str = String::from_utf8_lossy(&bytes);
@@ -60,16 +60,16 @@ impl std::fmt::Display for UiLocale {
 
 #[cfg(test)]
 mod tests {
-    use super::UiLocale;
+    use super::Locale;
 
     use proptest::prelude::*;
     use std::convert::TryFrom;
 
     const FR: u16 = 0x6672;
 
-    fn ui_locale_strategy() -> impl Strategy<Value = UiLocale> {
+    fn ui_locale_strategy() -> impl Strategy<Value = Locale> {
         proptest::num::u16::ANY.prop_filter_map("Invalid UI locale code", |code| {
-            let ui_locale = UiLocale(code);
+            let ui_locale = Locale(code);
             if ui_locale.to_string().is_ascii() {
                 Some(ui_locale)
             } else {
@@ -80,29 +80,29 @@ mod tests {
 
     #[test]
     fn from_str_fr() {
-        assert_eq!(UiLocale::try_from("fr").map(|code| code.as_u16()), Ok(FR));
+        assert_eq!(Locale::try_from("fr").map(|code| code.as_u16()), Ok(FR));
     }
 
     #[test]
     fn from_str_empty() {
-        assert!(UiLocale::try_from("").is_err())
+        assert!(Locale::try_from("").is_err())
     }
 
     #[test]
     fn from_str_too_long() {
-        assert!(UiLocale::try_from("fra").is_err())
+        assert!(Locale::try_from("fra").is_err())
     }
 
     #[test]
     fn to_str() {
-        assert_eq!(UiLocale(FR).to_string().as_str(), "fr")
+        assert_eq!(Locale(FR).to_string().as_str(), "fr")
     }
 
     proptest! {
         #[test]
         fn back_and_forth(ui_locale in ui_locale_strategy()) {
             let str = ui_locale.to_string();
-            assert_eq!(UiLocale::try_from(str.as_str()).map(|code| code.as_u16()), Ok(ui_locale.as_u16()))
+            assert_eq!(Locale::try_from(str.as_str()).map(|code| code.as_u16()), Ok(ui_locale.as_u16()))
         }
     }
 }

--- a/src/parsers/v1.rs
+++ b/src/parsers/v1.rs
@@ -140,6 +140,7 @@ named!(
                     battery_level: None,
                     current_alarm_codes: None,
                     patient_height: None,
+                    locale: None,
                 })
             })
     )
@@ -282,6 +283,7 @@ named!(
                 previous_inspiratory_duration: None,
                 battery_level: None,
                 patient_height: None,
+                locale: None,
             }))
     )
 );
@@ -525,6 +527,7 @@ mod tests {
                 battery_level: None,
                 current_alarm_codes: None,
                 patient_height: None,
+                locale: None,
             };
 
             // This needs to be consistent with sendStoppedMessage() defined in src/software/firmware/srcs/telemetry.cpp
@@ -675,6 +678,7 @@ mod tests {
                 previous_inspiratory_duration: None,
                 battery_level: None,
                 patient_height: None,
+                locale: None,
             };
 
             // This needs to be consistent with sendMachineStateSnapshot() defined in makair-firmware/srcs/telemetry.cpp

--- a/src/parsers/v1.rs
+++ b/src/parsers/v1.rs
@@ -139,6 +139,7 @@ named!(
                     inspiratory_duration_command: None,
                     battery_level: None,
                     current_alarm_codes: None,
+                    patient_height: None,
                 })
             })
     )
@@ -280,6 +281,7 @@ named!(
                 inspiratory_duration_command: None,
                 previous_inspiratory_duration: None,
                 battery_level: None,
+                patient_height: None,
             }))
     )
 );
@@ -522,6 +524,7 @@ mod tests {
                 inspiratory_duration_command: None,
                 battery_level: None,
                 current_alarm_codes: None,
+                patient_height: None,
             };
 
             // This needs to be consistent with sendStoppedMessage() defined in src/software/firmware/srcs/telemetry.cpp
@@ -671,6 +674,7 @@ mod tests {
                 inspiratory_duration_command: None,
                 previous_inspiratory_duration: None,
                 battery_level: None,
+                patient_height: None,
             };
 
             // This needs to be consistent with sendMachineStateSnapshot() defined in makair-firmware/srcs/telemetry.cpp

--- a/src/parsers/v2.rs
+++ b/src/parsers/v2.rs
@@ -3,6 +3,7 @@ use nom::IResult;
 use nom::{alt, do_parse, length_data, map, map_res, named, tag, take};
 use std::convert::TryFrom;
 
+use super::super::locale::Locale;
 use super::super::structures::*;
 
 const VERSION: u8 = 2;
@@ -239,6 +240,8 @@ named!(
             >> current_alarm_codes: u8_array
             >> sep
             >> patient_height: be_u8
+            >> sep
+            >> locale: be_u16
             >> end
             >> ({
                 TelemetryMessage::StoppedMessage(StoppedMessage {
@@ -288,6 +291,7 @@ named!(
                     battery_level: Some(battery_level),
                     current_alarm_codes: Some(current_alarm_codes),
                     patient_height: Some(patient_height),
+                    locale: Locale::try_from_u16(locale),
                 })
             })
     )
@@ -435,6 +439,8 @@ named!(
             >> battery_level: be_u16
             >> sep
             >> patient_height: be_u8
+            >> sep
+            >> locale: be_u16
             >> end
             >> (TelemetryMessage::MachineStateSnapshot(MachineStateSnapshot {
                 telemetry_version: VERSION,
@@ -490,6 +496,7 @@ named!(
                 previous_inspiratory_duration: Some(previous_inspiratory_duration),
                 battery_level: Some(battery_level),
                 patient_height: Some(patient_height),
+                locale: Locale::try_from_u16(locale),
             }))
     )
 );
@@ -888,6 +895,7 @@ mod tests {
                 battery_level: Some(battery_level),
                 current_alarm_codes: Some(current_alarm_codes),
                 patient_height: Some(patient_height),
+                locale: Some(Locale::default()),
             };
 
             // This needs to be consistent with sendStoppedMessage() defined in src/software/firmware/srcs/telemetry.cpp
@@ -962,6 +970,8 @@ mod tests {
                 &msg.current_alarm_codes.clone().unwrap_or_default(),
                 b"\t",
                 &msg.patient_height.unwrap_or_default().to_be_bytes(),
+                b"\t",
+                &msg.locale.unwrap_or_default().as_u16().to_be_bytes(),
                 b"\n",
             ]);
 
@@ -1130,6 +1140,7 @@ mod tests {
                 previous_inspiratory_duration: Some(previous_inspiratory_duration),
                 battery_level: Some(battery_level),
                 patient_height: Some(patient_height),
+                locale: Some(Locale::default()),
             };
 
             // This needs to be consistent with sendMachineStateSnapshot() defined in src/software/firmware/srcs/telemetry.cpp
@@ -1218,6 +1229,8 @@ mod tests {
                 &msg.battery_level.unwrap_or_default().to_be_bytes(),
                 b"\t",
                 &msg.patient_height.unwrap_or_default().to_be_bytes(),
+                b"\t",
+                &msg.locale.unwrap_or_default().as_u16().to_be_bytes(),
                 b"\n",
             ]);
 

--- a/src/parsers/v2.rs
+++ b/src/parsers/v2.rs
@@ -237,6 +237,8 @@ named!(
             >> battery_level: be_u16
             >> sep
             >> current_alarm_codes: u8_array
+            >> sep
+            >> patient_height: be_u8
             >> end
             >> ({
                 TelemetryMessage::StoppedMessage(StoppedMessage {
@@ -285,6 +287,7 @@ named!(
                     inspiratory_duration_command: Some(inspiratory_duration_command),
                     battery_level: Some(battery_level),
                     current_alarm_codes: Some(current_alarm_codes),
+                    patient_height: Some(patient_height),
                 })
             })
     )
@@ -430,6 +433,8 @@ named!(
             >> previous_inspiratory_duration: be_u16
             >> sep
             >> battery_level: be_u16
+            >> sep
+            >> patient_height: be_u8
             >> end
             >> (TelemetryMessage::MachineStateSnapshot(MachineStateSnapshot {
                 telemetry_version: VERSION,
@@ -484,6 +489,7 @@ named!(
                 inspiratory_duration_command: Some(inspiratory_duration_command),
                 previous_inspiratory_duration: Some(previous_inspiratory_duration),
                 battery_level: Some(battery_level),
+                patient_height: Some(patient_height),
             }))
     )
 );
@@ -845,6 +851,7 @@ mod tests {
             inspiratory_duration_command in num::u16::ANY,
             battery_level in num::u16::ANY,
             current_alarm_codes in collection::vec(0u8.., 0..100),
+            patient_height in num::u8::ANY,
         ) {
             let msg = StoppedMessage {
                 telemetry_version: VERSION,
@@ -880,6 +887,7 @@ mod tests {
                 inspiratory_duration_command: Some(inspiratory_duration_command),
                 battery_level: Some(battery_level),
                 current_alarm_codes: Some(current_alarm_codes),
+                patient_height: Some(patient_height),
             };
 
             // This needs to be consistent with sendStoppedMessage() defined in src/software/firmware/srcs/telemetry.cpp
@@ -952,6 +960,8 @@ mod tests {
                 b"\t",
                 &[msg.current_alarm_codes.clone().unwrap_or_default().len() as u8],
                 &msg.current_alarm_codes.clone().unwrap_or_default(),
+                b"\t",
+                &msg.patient_height.unwrap_or_default().to_be_bytes(),
                 b"\n",
             ]);
 
@@ -1076,6 +1086,7 @@ mod tests {
             inspiratory_duration_command in num::u16::ANY,
             previous_inspiratory_duration in num::u16::ANY,
             battery_level in num::u16::ANY,
+            patient_height in num::u8::ANY,
         ) {
             let msg = MachineStateSnapshot {
                 telemetry_version: VERSION,
@@ -1118,6 +1129,7 @@ mod tests {
                 inspiratory_duration_command: Some(inspiratory_duration_command),
                 previous_inspiratory_duration: Some(previous_inspiratory_duration),
                 battery_level: Some(battery_level),
+                patient_height: Some(patient_height),
             };
 
             // This needs to be consistent with sendMachineStateSnapshot() defined in src/software/firmware/srcs/telemetry.cpp
@@ -1204,6 +1216,8 @@ mod tests {
                 &msg.previous_inspiratory_duration.unwrap_or_default().to_be_bytes(),
                 b"\t",
                 &msg.battery_level.unwrap_or_default().to_be_bytes(),
+                b"\t",
+                &msg.patient_height.unwrap_or_default().to_be_bytes(),
                 b"\n",
             ]);
 

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -203,7 +203,7 @@ pub enum FatalErrorDetails {
     MassFlowMeterError,
     /// Read an inconsistent pressure
     InconsistentPressure {
-        /// Measured pressure in ùùH2O
+        /// Measured pressure in mmH2O
         pressure: u16,
     },
 }

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -386,6 +386,8 @@ pub struct StoppedMessage {
     pub battery_level: Option<u16>,
     /// [protocol v2] Codes of the alarms that are currently triggered
     pub current_alarm_codes: Option<Vec<u8>>,
+    /// [protocol v2] Patient's height in centimeters
+    pub patient_height: Option<u8>,
 }
 
 /// A telemetry message that is sent every time the firmware does a control iteration (every 10 ms)
@@ -508,6 +510,8 @@ pub struct MachineStateSnapshot {
     pub previous_inspiratory_duration: Option<u16>,
     /// [protocol v2] Measured battery level value in centivolts (precise value)
     pub battery_level: Option<u16>,
+    /// [protocol v2] Patient's height in centimeters
+    pub patient_height: Option<u8>,
 }
 
 /// A telemetry message that is sent every time an alarm is triggered or stopped

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -208,6 +208,94 @@ pub enum FatalErrorDetails {
     },
 }
 
+/// Step of the end of line test
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serialize-messages", derive(serde::Serialize))]
+#[allow(non_camel_case_types, missing_docs)]
+pub enum EolTestStep {
+    START,
+    SUPPLY_TO_EXPANDER_NOT_CONNECTED,
+    CHECK_FAN,
+    TEST_BAT_DEAD,
+    BATTERY_DEEP_DISCHARGE,
+    DISCONNECT_MAINS,
+    CONNECT_MAINS,
+    CHECK_BUZZER,
+    CHECK_ALL_BUTTONS,
+    CHECK_UI_SCREEN,
+    PLUG_AIR_TEST_SYTEM,
+    REACH_MAX_PRESSURE,
+    MAX_PRESSURE_REACHED_OK,
+    MAX_PRESSURE_NOT_REACHED,
+    START_LEAK_MESURE,
+    LEAK_IS_TOO_HIGH,
+    REACH_NULL_PRESSURE,
+    MIN_PRESSURE_NOT_REACHED,
+    USER_CONFIRMATION_BEFORE_O2_TEST,
+    START_O2_TEST,
+    O2_PRESSURE_NOT_REACH,
+    WAIT_USER_BEFORE_LONG_RUN,
+    START_LONG_RUN_BLOWER,
+    PRESSURE_NOT_STABLE,
+    FLOW_NOT_STABLE,
+    END_SUCCESS,
+    DISPLAY_PRESSURE,
+    DISPLAY_FLOW,
+}
+
+impl TryFrom<u8> for EolTestStep {
+    type Error = io::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::START),
+            1 => Ok(Self::SUPPLY_TO_EXPANDER_NOT_CONNECTED),
+            2 => Ok(Self::CHECK_FAN),
+            3 => Ok(Self::TEST_BAT_DEAD),
+            4 => Ok(Self::BATTERY_DEEP_DISCHARGE),
+            5 => Ok(Self::DISCONNECT_MAINS),
+            6 => Ok(Self::CONNECT_MAINS),
+            7 => Ok(Self::CHECK_BUZZER),
+            8 => Ok(Self::CHECK_ALL_BUTTONS),
+            9 => Ok(Self::CHECK_UI_SCREEN),
+            10 => Ok(Self::PLUG_AIR_TEST_SYTEM),
+            11 => Ok(Self::REACH_MAX_PRESSURE),
+            12 => Ok(Self::MAX_PRESSURE_REACHED_OK),
+            13 => Ok(Self::MAX_PRESSURE_NOT_REACHED),
+            14 => Ok(Self::START_LEAK_MESURE),
+            15 => Ok(Self::LEAK_IS_TOO_HIGH),
+            16 => Ok(Self::REACH_NULL_PRESSURE),
+            17 => Ok(Self::MIN_PRESSURE_NOT_REACHED),
+            18 => Ok(Self::USER_CONFIRMATION_BEFORE_O2_TEST),
+            19 => Ok(Self::START_O2_TEST),
+            20 => Ok(Self::O2_PRESSURE_NOT_REACH),
+            21 => Ok(Self::WAIT_USER_BEFORE_LONG_RUN),
+            22 => Ok(Self::START_LONG_RUN_BLOWER),
+            23 => Ok(Self::PRESSURE_NOT_STABLE),
+            24 => Ok(Self::FLOW_NOT_STABLE),
+            25 => Ok(Self::END_SUCCESS),
+            26 => Ok(Self::DISPLAY_PRESSURE),
+            27 => Ok(Self::DISPLAY_FLOW),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Invalid EOL test step {}", value),
+            )),
+        }
+    }
+}
+
+/// Content of end of line test snapshots
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize-messages", derive(serde::Serialize))]
+pub enum EolTestSnapshotContent {
+    /// Test is in progress
+    InProgress,
+    /// There was an error during test
+    Error(String),
+    /// End of line test succeeded
+    Success,
+}
+
 /// A telemetry message that is sent once every time the MCU boots
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize-messages", derive(serde::Serialize))]
@@ -494,6 +582,24 @@ pub struct FatalError {
     pub error: FatalErrorDetails,
 }
 
+/// [protocol v2] A message sent during end of line tests
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize-messages", derive(serde::Serialize))]
+pub struct EolTestSnapshot {
+    /// Version of the telemetry protocol
+    pub telemetry_version: u8,
+    /// Version of the MCU firmware
+    pub version: String,
+    /// Internal ID of the MCU
+    pub device_id: String,
+    /// Number of microseconds since the MCU booted
+    pub systick: u64,
+    /// Current step
+    pub current_step: EolTestStep,
+    /// Content of the snapshot
+    pub content: EolTestSnapshotContent,
+}
+
 /// Supported telemetry messages
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize-messages", derive(serde::Serialize))]
@@ -513,6 +619,8 @@ pub enum TelemetryMessage {
     ControlAck(ControlAck),
     /// [protocol v2] A message sent when a fatal error occurs
     FatalError(FatalError),
+    /// [protocol v2] A message sent during end of line tests
+    EolTestSnapshot(EolTestSnapshot),
 }
 
 impl TelemetryMessage {
@@ -540,6 +648,9 @@ impl TelemetryMessage {
             Self::FatalError(FatalError {
                 telemetry_version, ..
             }) => telemetry_version,
+            Self::EolTestSnapshot(EolTestSnapshot {
+                telemetry_version, ..
+            }) => telemetry_version,
         };
         *val
     }
@@ -554,6 +665,7 @@ impl TelemetryMessage {
             Self::AlarmTrap(AlarmTrap { version, .. }) => version,
             Self::ControlAck(ControlAck { version, .. }) => version,
             Self::FatalError(FatalError { version, .. }) => version,
+            Self::EolTestSnapshot(EolTestSnapshot { version, .. }) => version,
         };
         val.clone()
     }
@@ -568,6 +680,7 @@ impl TelemetryMessage {
             Self::AlarmTrap(AlarmTrap { device_id, .. }) => device_id,
             Self::ControlAck(ControlAck { device_id, .. }) => device_id,
             Self::FatalError(FatalError { device_id, .. }) => device_id,
+            Self::EolTestSnapshot(EolTestSnapshot { device_id, .. }) => device_id,
         };
         val.clone()
     }
@@ -582,6 +695,7 @@ impl TelemetryMessage {
             Self::AlarmTrap(AlarmTrap { systick, .. }) => systick,
             Self::ControlAck(ControlAck { systick, .. }) => systick,
             Self::FatalError(FatalError { systick, .. }) => systick,
+            Self::EolTestSnapshot(EolTestSnapshot { systick, .. }) => systick,
         };
         *val
     }

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -8,6 +8,7 @@ use std::convert::TryFrom;
 use std::io;
 
 pub use crate::control::ControlSetting;
+use crate::locale::Locale;
 
 /// Variants of the MakAir firmware
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -388,6 +389,8 @@ pub struct StoppedMessage {
     pub current_alarm_codes: Option<Vec<u8>>,
     /// [protocol v2] Patient's height in centimeters
     pub patient_height: Option<u8>,
+    /// [protocol v2] Language of the system
+    pub locale: Option<Locale>,
 }
 
 /// A telemetry message that is sent every time the firmware does a control iteration (every 10 ms)
@@ -512,6 +515,8 @@ pub struct MachineStateSnapshot {
     pub battery_level: Option<u16>,
     /// [protocol v2] Patient's height in centimeters
     pub patient_height: Option<u8>,
+    /// [protocol v2] Language of the system
+    pub locale: Option<Locale>,
 }
 
 /// A telemetry message that is sent every time an alarm is triggered or stopped


### PR DESCRIPTION
- [x] Add setting to persist UI locale #31
- [x] Add a new telemetry message for errors #33 
- [ ] Add a new telemetry message for EOL test results #34
  - [ ] Add data in success messages
- [x] Add new setting (+ in stopped & machine state) → patient's height in cm
- [x] Prepare a PR in makair-firmware